### PR TITLE
Change media type to application/ubjson

### DIFF
--- a/spec/spec.rst
+++ b/spec/spec.rst
@@ -802,7 +802,7 @@ MIME Type
 The Universal Binary JSON specification is a binary format and recommends using
 the following mime type::
 
-  application/x-ubjson
+  application/ubjson
 
 This was added directly to the specification in hopes of avoiding
 `similar confusion with JSON`_.


### PR DESCRIPTION
Using the `x-` convention is not recommended anymore as it often leads to interoperability problems when it is dropped at a later stage. Thus, the media type should be changed to `application/ubjson`

See http://tools.ietf.org/html/rfc6648
